### PR TITLE
CA-208547: Avoid races in pointing stdin/stdout/stderr at /dev/null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 sudo: true
 env:
-        - OCAML_VERSION=4.02 PACKAGE=xapi-idl FORK_USER=xapi-project EXTRA_REMOTES=git://github.com/xapi-project/opam-repo-dev
+        - OCAML_VERSION=4.02 PACKAGE=xapi-idl EXTRA_REMOTES=git://github.com/xapi-project/opam-repo-dev

--- a/lib/xcp_service.ml
+++ b/lib/xcp_service.ml
@@ -554,13 +554,11 @@ let daemonize ?start_fn () =
 			Unix.chdir "/";
 			mkdir_rec (Filename.dirname !pidfile) 0o755;
 			pidfile_write !pidfile;
-			Unix.close Unix.stdin;
-			Unix.close Unix.stdout;
-			Unix.close Unix.stderr;
 			let nullfd = Unix.openfile "/dev/null" [ Unix.O_RDWR ] 0 in
-			assert (nullfd = Unix.stdin);
-			let (_:Unix.file_descr) = Unix.dup nullfd in ();
-			let (_:Unix.file_descr) = Unix.dup nullfd in ();
+			Unix.dup2 nullfd Unix.stdin;
+			Unix.dup2 nullfd Unix.stdout;
+			Unix.dup2 nullfd Unix.stderr;
+			Unix.close nullfd
 		| _ -> exit 0)
 	| _ -> exit 0
 

--- a/opam
+++ b/opam
@@ -1,11 +1,17 @@
-opam-version: "1"
+opam-version: "1.2"
+authors: "Dave Scott"
+homepage: "https://github.com/xapi-project/xcp-idl"
+bug-reports: "https://github.com/xapi-project/xcp-idl/issues"
+dev-repo: "git://github.com/xapi-project/xcp-idl"
 maintainer: "dave.scott@eu.citrix.com"
 build: [
   [make "all"]
-  [make "install"]
 ]
 build-test: [
   [make "test"]
+]
+install: [
+  [make "install"]
 ]
 remove: [
   ["ocamlfind" "remove" "xcp"]


### PR DESCRIPTION
The two calls to Unix.dup are intended to point stdout and stderr at
/dev/null - this will normally be the case, as Unix.dup will open the
next available file descriptor and stdout/stderr have just been closed.

However, there are many ways this can go wrong - if an open() happens
in another thread it could mean that...
- nullfd <> Unix.stdin - this is checked for, but there is no error
  handling if this fails
- one or both of the Unix.dup calls do not point stdout/stderr at
  /dev/null as intended, but instead open new file descriptors.

This change instead uses Unix.dup2 which atomically closes the second
file descriptor and copies it from the first. This also allows the
explicit calls to Unix.close to be removed. Finally, nullfd is closed as
it is not needed after the calls to Unix.dup2.

Signed-off-by: John Else john.else@citrix.com
